### PR TITLE
white/blacklist implemented (#44) + docs/tests updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,12 @@ var Server = require('bittorrent-tracker').Server
 
 var server = new Server({
   udp: true, // enable udp server? [default=true]
-  http: true // enable http server? [default=true]
+  http: true, // enable http server? [default=true]
+  filter: function (hash) {
+    // specify white/blacklist for disallowing/allowing torrents
+    return hash !== 'aaa67059ed6bd08362da625b3ae77f6f4a075aaa'
+  })
+
 })
 
 server.on('error', function (err) {


### PR DESCRIPTION
I've added a simple filter option to the server creation parameters as per issue #44.

If ```filter()``` returns false, a warning is emitted and the infoHash is not added to ```self._torrents```. The test checks this by ensuring that the infoHash does not appear in a scrape request.