### PR TITLE
server: rm check for http/udp option

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,9 +36,6 @@ function Server (opts) {
   EventEmitter.call(self)
   opts = opts || {}
 
-  if (opts.http === false && opts.udp === false)
-    throw new Error('must start at least one type of server (http or udp)')
-
   self._intervalMs = opts.interval
     ? opts.interval
     : 10 * 60 * 1000 // 10 min


### PR DESCRIPTION
This seems to have been introduced recently, and I understand why, but: my use-case brings its own http server, I just use `onHttpRequest()`. There is no need for an implicit listening socket.