### PR TITLE
Exposed full http request to filter function for more configurable filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,13 @@ var Server = require('bittorrent-tracker').Server
 var server = new Server({
   udp: true, // enable udp server? [default=true]
   http: true, // enable http server? [default=true]
-  filter: function (infoHash) {
+  filter: function (params) {
     // black/whitelist for disallowing/allowing torrents [default=allow all]
     // this example only allows this one torrent
-    return infoHash === 'aaa67059ed6bd08362da625b3ae77f6f4a075aaa'
+    return params.info_hash === 'aaa67059ed6bd08362da625b3ae77f6f4a075aaa'
+    
+    // you can also block by peer id (whitelisting torrent clients) or by
+    // secret key, as you get full access to the original http request
   })
 })
 

--- a/examples/express-embed/server.js
+++ b/examples/express-embed/server.js
@@ -4,9 +4,20 @@ var Server = require('../..').Server
 var express = require('express')
 var app = express()
 
+// https://wiki.theory.org/BitTorrentSpecification#peer_id
+var whitelist = {
+  UT: true // uTorrent
+}
+
 var server = new Server({
   http: false, // we do our own
-  udp: false   // not interested
+  udp: false,  // not interested
+  filter: function (params) {
+    // black/whitelist for disallowing/allowing specific clients [default=allow all]
+    // this example only allows the uTorrent client
+    var client = params.peer_id[1] + params.peer_id[2]
+    return whitelist[client]
+  }
 })
 
 var onHttpRequest = server.onHttpRequest.bind(server)

--- a/server.js
+++ b/server.js
@@ -109,10 +109,10 @@ Server.prototype.close = function (cb) {
   }
 }
 
-Server.prototype.getSwarm = function (infoHash) {
+Server.prototype.getSwarm = function (infoHash, params) {
   var self = this
-  if (Buffer.isBuffer(infoHash)) infoHash = infoHash.toString('hex')
-  if (self._filter && !self._filter(infoHash)) return null
+  if (Buffer.isBuffer(infoHash)) infoHash = params.info_hash = infoHash.toString('hex')
+  if (self._filter && !self._filter(params)) return null
   var swarm = self.torrents[infoHash]
   if (!swarm) swarm = self.torrents[infoHash] = new Swarm(infoHash, this)
   return swarm
@@ -207,7 +207,7 @@ Server.prototype._onRequest = function (params, cb) {
 
 Server.prototype._onAnnounce = function (params, cb) {
   var self = this
-  var swarm = self.getSwarm(params.info_hash)
+  var swarm = self.getSwarm(params.info_hash, params)
   if (swarm === null) return cb(new Error('disallowed info_hash'))
   if (!params.event || params.event === 'empty') params.event = 'update'
   swarm.announce(params, function (err, response) {


### PR DESCRIPTION
Can filter by torrent client type and version, IP, and auth key because full http request is exposed.  Useful for private trackers.