### PR TITLE
[Client] Fix question mark in announceUrl

### DIFF
--- a/client.js
+++ b/client.js
@@ -274,7 +274,7 @@ Tracker.prototype._requestHttp = function (requestUrl, opts) {
     }
   }
 
-  get.concat(requestUrl + '?' + common.querystringStringify(opts), function (err, data, res) {
+  get.concat(requestUrl + ((requestUrl.indexOf('?') !== -1) ? '&' : '?') + common.querystringStringify(opts), function (err, data, res) {
     if (err) return self.client.emit('warning', err)
     if (res.statusCode !== 200) return self.client.emit('warning', new Error('Non-200 response code ' + res.statusCode + ' from ' + requestUrl))
     if (data && data.length) self._handleResponse(requestUrl, data)


### PR DESCRIPTION
In most cases, Private Tracker has an announce with "?" inside, e.g. "http://server:port?passkey=key".