### PR TITLE
reuseAddr for dgram.CreateSocket

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,12 +66,12 @@ function Server (opts) {
 
   // start a udp tracker unless the user explicitly says no
   if (opts.udp !== false) {
-    self.udp4 = self.udp = dgram.createSocket('udp4')
+    self.udp4 = self.udp = dgram.createSocket({type: 'udp4', reuseAddr: true})
     self.udp4.on('message', self.onUdpRequest.bind(self))
     self.udp4.on('error', self._onError.bind(self))
     self.udp4.on('listening', onListening)
 
-    self.udp6 = dgram.createSocket('udp6')
+    self.udp6 = dgram.createSocket({type: 'udp6', reuseAddr: true})
     self.udp6.on('message', self.onUdpRequest.bind(self))
     self.udp6.on('error', self._onError.bind(self))
     self.udp6.on('listening', onListening)


### PR DESCRIPTION
Creating a udp4 and udp6 socket on the same port can result in "ERROR: bind EADDRINUSE". Passing reuseAddr: true fixes this.