### PR TITLE
Expiring peer data using node-cache

### DIFF
--- a/lib/swarm.js
+++ b/lib/swarm.js
@@ -9,8 +9,8 @@ var NodeCache = require('node-cache')
 // need to support when overriding Server.getSwarm()
 function Swarm (infoHash, server) {
   var self = this
-  // 900 seconds === 15 minutes
-  this.cache = new NodeCache({checkperiod: 0, stdTTL: 900, useClones: false})
+  var ttl = 900 // 900s = 15 minutes
+  this.cache = new NodeCache({checkperiod: 0, stdTTL: ttl, useClones: false})
   this.peers = {
     get: function (key) {
       return self.cache.get(key)
@@ -23,6 +23,9 @@ function Swarm (infoHash, server) {
     },
     keys: function () {
       return self.cache.keys()
+    },
+    ttl: function (key) {
+      return self.cache.ttl(key, self.ttl)
     }
   }
   this.complete = 0
@@ -104,6 +107,8 @@ Swarm.prototype._onAnnounce_update = function (params, peer) {
     debug('unexpected `update` event from peer that is not in swarm')
     return this._onAnnounce_started(params, peer) // treat as a start
   }
+
+  this.peers.ttl(params.addr || params.peer_id)
 
   if (!peer.complete && params.left === 0) {
     this.complete += 1

--- a/lib/swarm.js
+++ b/lib/swarm.js
@@ -3,17 +3,35 @@ module.exports = Swarm
 var debug = require('debug')('bittorrent-tracker')
 var randomIterate = require('random-iterate')
 
+var NodeCache = require('node-cache')
+
 // Regard this as the default implementation of an interface that you
 // need to support when overriding Server.getSwarm()
 function Swarm (infoHash, server) {
-  this.peers = {}
+  var self = this
+  // 900 seconds === 15 minutes
+  this.cache = new NodeCache({checkperiod: 0, stdTTL: 900, useClones: false})
+  this.peers = {
+    get: function (key) {
+      return self.cache.get(key)
+    },
+    set: function (key, value) {
+      return self.cache.set(key, value)
+    },
+    del: function (key) {
+      return self.cache.del(key)
+    },
+    keys: function () {
+      return self.cache.keys()
+    }
+  }
   this.complete = 0
   this.incomplete = 0
 }
 
 Swarm.prototype.announce = function (params, cb) {
   var self = this
-  var peer = self.peers[params.addr || params.peer_id]
+  var peer = self.peers.get(params.addr || params.peer_id)
 
   // Dispatch announce event
   var fn = '_onAnnounce_' + params.event
@@ -46,13 +64,13 @@ Swarm.prototype._onAnnounce_started = function (params, peer) {
 
   if (params.left === 0) this.complete += 1
   else this.incomplete += 1
-  peer = this.peers[params.addr || params.peer_id] = {
+  peer = this.peers.set((params.addr || params.peer_id), {
     complete: params.left === 0,
     ip: params.ip, // only http+udp
     peerId: params.peer_id, // as hex
     port: params.port, // only http+udp
     socket: params.socket // only websocket
-  }
+  })
 }
 
 Swarm.prototype._onAnnounce_stopped = function (params, peer) {
@@ -63,7 +81,7 @@ Swarm.prototype._onAnnounce_stopped = function (params, peer) {
 
   if (peer.complete) this.complete -= 1
   else this.incomplete -= 1
-  this.peers[params.addr || params.peer_id] = null
+  this.peers.del(params.addr || params.peer_id)
 }
 
 Swarm.prototype._onAnnounce_completed = function (params, peer) {
@@ -96,11 +114,11 @@ Swarm.prototype._onAnnounce_update = function (params, peer) {
 
 Swarm.prototype._getPeers = function (numWant, peerType) {
   var peers = []
-  var ite = randomIterate(Object.keys(this.peers))
+  var ite = randomIterate(this.peers.keys())
   while (true) {
     var peerId = ite()
     if (peers.length >= numWant || peerId == null) return peers
-    var peer = this.peers[peerId]
+    var peer = this.peers.get(peerId)
     if (peer &&
         ((peerType === 'webrtc' && peer.socket) || (peerType === 'addr' && peer.ip))) {
       peers.push(peer)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "inherits": "^2.0.1",
     "ip": "^0.3.0",
     "minimist": "^1.1.1",
+    "node-cache": "^3.0.0",
     "once": "^1.3.0",
     "random-iterate": "^1.0.1",
     "run-series": "^1.0.2",

--- a/server.js
+++ b/server.js
@@ -342,7 +342,7 @@ Server.prototype._onWebSocketRequest = function (socket, params) {
       if (!swarm) {
         return self.emit('warning', new Error('no swarm with that `info_hash`'))
       }
-      var toPeer = swarm.peers[params.to_peer_id]
+      var toPeer = swarm.peers.get(params.to_peer_id)
       if (!toPeer) {
         return self.emit('warning', new Error('no peer with that `to_peer_id`'))
       }

--- a/test/server.js
+++ b/test/server.js
@@ -54,8 +54,8 @@ function serverTest (t, serverType, serverFamily) {
       t.equal(Object.keys(server.torrents).length, 1)
       t.equal(swarm.complete, 0)
       t.equal(swarm.incomplete, 1)
-      t.equal(Object.keys(swarm.peers).length, 1)
-      t.deepEqual(swarm.peers[clientAddr + ':6881'], {
+      t.equal(swarm.peers.keys().length, 1)
+      t.deepEqual(swarm.peers.get(clientAddr + ':6881'), {
         ip: clientIp,
         port: 6881,
         peerId: peerId.toString('hex'),


### PR DESCRIPTION
This is an example I've written up somewhat naively for issue #4. Please use for ideas to solve the issue.

I used node-cache module to set up the peer values in the swarm, which allows for expiring peers. In this example, I set it arbitrarily to 15 minutes.

~~~I'm pretty sure the peer TTL will need to be changed (node-cache lets you do this: https://www.npmjs.com/package/node-cache#change-ttl-ttl) upon an update announce, which will let the peer detail to keep having fresh data. Haven't done that yet in this PR.~~~

Peer's TTL is updated upon an update announce.