### PR TITLE
adhere to padded-blocks

### DIFF
--- a/server.js
+++ b/server.js
@@ -438,7 +438,6 @@ Server.prototype._onAnnounce = function (params, cb) {
       cb(null, response)
     })
   }
-
 }
 
 Server.prototype._onScrape = function (params, cb) {


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.