### PR TITLE
Provide a way to give extra data on announce

### DIFF
--- a/client.js
+++ b/client.js
@@ -53,6 +53,7 @@ function Client (peerId, port, torrent, opts) {
 
   self._rtcConfig = opts.rtcConfig
   self._wrtc = opts.wrtc
+  self._getAnnounceOpts = opts.getAnnounceOpts
 
   debug('new client %s', self.infoHash)
 
@@ -268,5 +269,10 @@ Client.prototype._defaultAnnounceOpts = function (opts) {
   if (opts.left == null && self.torrentLength != null) {
     opts.left = self.torrentLength - opts.downloaded
   }
+
+  if (opts.getAnnounceOpts == null) {
+    opts.getAnnounceOpts = self._getAnnounceOpts
+  }
+
   return opts
 }

--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -40,15 +40,26 @@ HTTPTracker.prototype.announce = function (opts) {
   var self = this
   if (self.destroyed) return
 
+  // Refresh opts if the callback is provided
+  var cbopts
+  if (opts.getAnnounceOpts) {
+    cbopts = opts.getAnnounceOpts()
+    if (cbopts.uploaded) opts.uploaded = cbopts.uploaded
+    if (cbopts.downloaded) opts.downloaded = cbopts.downloaded
+    if (cbopts.left) opts.left = cbopts.left
+  }
+
   var params = {
     numwant: opts.numwant,
     uploaded: opts.uploaded,
     downloaded: opts.downloaded,
+    left: opts.left,
     event: opts.event,
     compact: (opts.compact == null) ? 1 : opts.compact,
     info_hash: self.client._infoHashBinary,
     peer_id: self.client._peerIdBinary,
-    port: self.client._port
+    port: self.client._port,
+    extras: cbopts && cbopts.extraAnnounceOpts
   }
   if (self._trackerId) params.trackerid = self._trackerId
 

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -189,6 +189,15 @@ UDPTracker.prototype._request = function (opts) {
   function announce (connectionId, opts) {
     transactionId = genTransactionId()
 
+    // Refresh opts if the callback is provided
+    var cbopts
+    if (opts.getAnnounceOpts) {
+      cbopts = opts.getAnnounceOpts()
+      if (cbopts.uploaded) opts.uploaded = cbopts.uploaded
+      if (cbopts.downloaded) opts.downloaded = cbopts.downloaded
+      if (cbopts.left) opts.left = cbopts.left
+    }
+
     send(Buffer.concat([
       connectionId,
       common.toUInt32(common.ACTIONS.ANNOUNCE),

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -46,15 +46,26 @@ WebSocketTracker.prototype.announce = function (opts) {
   // Limit the number of offers that are generated, since it can be slow
   var numwant = Math.min(opts.numwant, 10)
 
+  // Refresh opts if the callback is provided
+  var cbopts
+  if (opts.getAnnounceOpts) {
+    cbopts = opts.getAnnounceOpts()
+    if (cbopts.uploaded) opts.uploaded = cbopts.uploaded
+    if (cbopts.downloaded) opts.downloaded = cbopts.downloaded
+    if (cbopts.left) opts.left = cbopts.left
+  }
+
   self._generateOffers(numwant, function (offers) {
     var params = {
       numwant: numwant,
       uploaded: opts.uploaded || 0,
       downloaded: opts.downloaded,
+      left: opts.left,
       event: opts.event,
       info_hash: self.client._infoHashBinary,
       peer_id: self.client._peerIdBinary,
-      offers: offers
+      offers: offers,
+      extras: cbopts && cbopts.extraAnnounceOpts
     }
     if (self._trackerId) params.trackerid = self._trackerId
 


### PR DESCRIPTION
This PR adds a callback named getAnnounceOpts to the client options to be able to send updated data to the tracker (downloaded, uploaded, left and extra...).

The extra data can be handled in a tracker by listening to the event params.

I will send PRs for torrent-discovery and webtorrent in order to make this available in webtorrent. 