### PR TITLE
Remove info_hash from failure reason

### DIFF
--- a/server.js
+++ b/server.js
@@ -311,8 +311,7 @@ Server.prototype._onWebSocketRequest = function (socket, params) {
     params = parseWebSocketRequest(socket, params)
   } catch (err) {
     socket.send(JSON.stringify({
-      'failure reason': err.message,
-      info_hash: common.hexToBinary(params.info_hash)
+      'failure reason': err.message
     }), socket.onSend)
 
     // even though it's an error for the client, it's just a warning for the server.


### PR DESCRIPTION
If a client doesn't send the key `info_hash` (or sends it empty) in the request, then `parseWebSocketRequest` throws an Error.

Therefore, the key `info_hash` should not be used in the catch block, otherwise it will throw a TypeError while creating a `new Buffer`:

```
buffer.js:188
        throw new TypeError('First argument needs to be a number, ' +
              ^
TypeError: First argument needs to be a number, array or string.
    at new Buffer (buffer.js:188:15)
    at Object.exports.hexToBinary (/tracker2/node_modules/bittorrent-tracker/lib/common.js:15:10)
    at Server._onWebSocketRequest (/tracker2/node_modules/bittorrent-tracker/server.js:316:25)
    at WebSocket.EventEmitter.emit (events.js:98:17)
    at Receiver.ontext (/tracker2/node_modules/bittorrent-tracker/node_modules/ws/lib/WebSocket.js:816:10)
    at /tracker2/node_modules/bittorrent-tracker/node_modules/ws/lib/Receiver.js:477:18
    at /tracker2/node_modules/bittorrent-tracker/node_modules/ws/lib/Receiver.js:361:7
    at /tracker2/node_modules/bittorrent-tracker/node_modules/ws/lib/PerMessageDeflate.js:247:5
    at afterWrite (_stream_writable.js:274:3)
    at onwrite (_stream_writable.js:266:7)
```