### PR TITLE
Delete peer on announce stopped

### DIFF
--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -66,7 +66,7 @@ Swarm.prototype._onAnnounceStopped = function (params, peer) {
 
   if (peer.complete) this.complete -= 1
   else this.incomplete -= 1
-  this.peers[params.addr || params.peer_id] = null
+  delete this.peers[params.addr || params.peer_id]
 }
 
 Swarm.prototype._onAnnounceCompleted = function (params, peer) {


### PR DESCRIPTION
It's better to delete as iterating over the peers will be much faster