### PR TITLE
Reconnect timeout improvement

### DIFF
--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -15,8 +15,8 @@ var Tracker = require('./tracker')
 // boost, and saves browser resources.
 var socketPool = {}
 
-var RECONNECT_VARIANCE = 30 * 1000
-var RECONNECT_MINIMUM = 5 * 1000
+var RECONNECT_MINIMUM = 15 * 1000
+var RECONNECT_RETRY = 30 * 1000
 var OFFER_TIMEOUT = 50 * 1000
 
 inherits(WebSocketTracker, Tracker)
@@ -29,6 +29,7 @@ function WebSocketTracker (client, announceUrl, opts) {
   self.peers = {} // peers (offer id -> peer)
   self.socket = null
   self.reconnecting = false
+  self.retries = 0
 
   self._openSocket()
 }
@@ -118,6 +119,7 @@ WebSocketTracker.prototype._onSocketConnect = function () {
 
   if (self.reconnecting) {
     self.reconnecting = false
+    self.retries = 0
     self.announce(self.client._defaultAnnounceOpts())
   }
 }
@@ -233,10 +235,11 @@ WebSocketTracker.prototype._onSocketError = function (err) {
 
 WebSocketTracker.prototype._startReconnectTimer = function () {
   var self = this
-  var ms = Math.floor(Math.random() * RECONNECT_VARIANCE) + RECONNECT_MINIMUM
+  var ms = RECONNECT_MINIMUM + (self.retries * RECONNECT_RETRY)
 
   self.reconnecting = true
   var reconnectTimer = setTimeout(function () {
+    self.retries++
     self._openSocket()
   }, ms)
   if (reconnectTimer.unref) reconnectTimer.unref()

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -16,8 +16,8 @@ var Tracker = require('./tracker')
 var socketPool = {}
 
 var RECONNECT_MINIMUM = 15 * 1000
-var RECONNECT_MAXIMUM = 5 * 60 * 1000
-var RECONNECT_RETRY = 30 * 1000
+var RECONNECT_MAXIMUM = 30 * 60 * 1000
+var RECONNECT_VARIANCE = 30 * 1000
 var OFFER_TIMEOUT = 50 * 1000
 
 inherits(WebSocketTracker, Tracker)
@@ -236,7 +236,7 @@ WebSocketTracker.prototype._onSocketError = function (err) {
 
 WebSocketTracker.prototype._startReconnectTimer = function () {
   var self = this
-  var ms = Math.min(RECONNECT_MINIMUM + (self.retries * RECONNECT_RETRY), RECONNECT_MAXIMUM)
+  var ms = Math.floor(Math.random() * RECONNECT_VARIANCE) + Math.min(Math.pow(2, self.retries) * RECONNECT_MINIMUM, RECONNECT_MAXIMUM)
 
   self.reconnecting = true
   var reconnectTimer = setTimeout(function () {

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -16,6 +16,7 @@ var Tracker = require('./tracker')
 var socketPool = {}
 
 var RECONNECT_MINIMUM = 15 * 1000
+var RECONNECT_MAXIMUM = 5 * 60 * 1000
 var RECONNECT_RETRY = 30 * 1000
 var OFFER_TIMEOUT = 50 * 1000
 
@@ -235,7 +236,7 @@ WebSocketTracker.prototype._onSocketError = function (err) {
 
 WebSocketTracker.prototype._startReconnectTimer = function () {
   var self = this
-  var ms = RECONNECT_MINIMUM + (self.retries * RECONNECT_RETRY)
+  var ms = Math.min(RECONNECT_MINIMUM + (self.retries * RECONNECT_RETRY), RECONNECT_MAXIMUM)
 
   self.reconnecting = true
   var reconnectTimer = setTimeout(function () {


### PR DESCRIPTION
Minimum set at 15 seconds, each retry adds 30 seconds.

Fixes [webtorrent#659](https://github.com/feross/webtorrent/issues/659)

