### PR TITLE
Bugfix: Do not use params.ip to filter Websocket peers

### DIFF
--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -52,10 +52,11 @@ Swarm.prototype._onAnnounceStarted = function (params, peer) {
   else this.incomplete += 1
   var id = params.type === 'ws' ? params.peer_id : params.addr
   peer = this.peers[id] = {
+    type: params.type,
     complete: params.left === 0,
     peerId: params.peer_id, // as hex
-    ip: params.ip, // only http, udp
-    port: params.port, // only http, udp
+    ip: params.ip,
+    port: params.port,
     socket: params.socket // only websocket
   }
 }
@@ -107,7 +108,7 @@ Swarm.prototype._getPeers = function (numwant, ownPeerId, isWebRTC) {
   while ((peerId = ite()) && peers.length < numwant) {
     var peer = this.peers[peerId]
     if (isWebRTC && peer.peerId === ownPeerId) continue // don't send peer to itself
-    if ((isWebRTC && peer.ip) || (!isWebRTC && peer.socket)) continue // send proper peer type
+    if ((isWebRTC && peer.type !== 'ws') || (!isWebRTC && peer.type === 'ws')) continue // send proper peer type
     peers.push(peer)
   }
   return peers

--- a/test/server.js
+++ b/test/server.js
@@ -46,6 +46,7 @@ function serverTest (t, serverType, serverFamily) {
         t.equal(swarm.incomplete, 1)
         t.equal(Object.keys(swarm.peers).length, 1)
         t.deepEqual(swarm.peers[hostname + ':6881'], {
+          type: serverType,
           ip: clientIp,
           port: 6881,
           peerId: peerId.toString('hex'),


### PR DESCRIPTION
I have introduced a bug in 7.4.0 because `params.ip` is used to filter peers in `Swarm._getPeers`. To fix this, I propose the addition of `params.type` in the peer data to filter against this.

What do you think?