### PR TITLE
invoke callbacks of destroyed trackers

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -74,7 +74,7 @@ HTTPTracker.prototype.scrape = function (opts) {
 
 HTTPTracker.prototype.destroy = function (cb) {
   var self = this
-  if (self.destroyed) return
+  if (self.destroyed) return cb && cb()
   self.destroyed = true
   clearInterval(self.interval)
 

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -47,7 +47,7 @@ UDPTracker.prototype.scrape = function (opts) {
 
 UDPTracker.prototype.destroy = function (cb) {
   var self = this
-  if (self.destroyed) return
+  if (self.destroyed) return cb && cb()
   self.destroyed = true
   clearInterval(self.interval)
 

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -66,7 +66,7 @@ WebSocketTracker.prototype.scrape = function (opts) {
 
 WebSocketTracker.prototype.destroy = function (onclose) {
   var self = this
-  if (self.destroyed) return
+  if (self.destroyed) return onclose && onclose()
   self.destroyed = true
   clearInterval(self.interval)
 


### PR DESCRIPTION
Currently the client [waits for the callback signal of all trackers](https://github.com/feross/bittorrent-tracker/blob/master/client.js#L246) - including the ones which were previously unable to connect and destroyed. Since the process stays open, the torrents which reference them as their discovery won't be destroyed either and in the end prevent closing the [webtorrent client] (https://github.com/feross/webtorrent/blob/master/index.js#L322).