### PR TITLE
Add testing for websocket server (WIP: Do not merge)

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -74,7 +74,7 @@ HTTPTracker.prototype.scrape = function (opts) {
 
 HTTPTracker.prototype.destroy = function (cb) {
   var self = this
-  if (self.destroyed) return cb && cb()
+  if (self.destroyed) return cb(null)
   self.destroyed = true
   clearInterval(self.interval)
 

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -47,7 +47,7 @@ UDPTracker.prototype.scrape = function (opts) {
 
 UDPTracker.prototype.destroy = function (cb) {
   var self = this
-  if (self.destroyed) return cb && cb()
+  if (self.destroyed) return cb(null)
   self.destroyed = true
   clearInterval(self.interval)
 

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -89,6 +89,15 @@ WebSocketTracker.prototype.destroy = function (cb) {
   clearInterval(self.interval)
   clearTimeout(self.reconnectTimer)
 
+  // Destroy peers
+  for(var peerId in self.peers) {
+    var peer = self.peers[peerId]
+    clearTimeout(peer.trackerTimeout)
+    peer.destroy()
+  }
+  delete self.peers
+
+  // Close socked
   if (socketPool[self.announceUrl]) socketPool[self.announceUrl].consumers--
 
   self.socket.removeListener('connect', self._onSocketConnectBound)

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -90,7 +90,7 @@ WebSocketTracker.prototype.destroy = function (cb) {
   clearTimeout(self.reconnectTimer)
 
   // Destroy peers
-  for(var peerId in self.peers) {
+  for (var peerId in self.peers) {
     var peer = self.peers[peerId]
     clearTimeout(peer.trackerTimeout)
     peer.destroy()
@@ -116,9 +116,9 @@ WebSocketTracker.prototype.destroy = function (cb) {
     self.socket.on('error', noop) // ignore all future errors
 
     try {
-      self.socket.destroy(onclose)
+      self.socket.destroy(cb)
     } catch (err) {
-      if (onclose) onclose()
+      if (cb) cb()
     }
   }
 

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -88,7 +88,7 @@ WebSocketTracker.prototype.destroy = function (cb) {
   self.destroyed = true
   clearInterval(self.interval)
 
-  delete socketPool[self.announceUrl]
+  if (socketPool[self.announceUrl]) socketPool[self.announceUrl].consumers--
 
   self.socket.removeListener('connect', self._onSocketConnectBound)
   self.socket.removeListener('data', self._onSocketDataBound)
@@ -100,11 +100,16 @@ WebSocketTracker.prototype.destroy = function (cb) {
   self._onSocketDataBound = null
   self._onSocketCloseBound = null
 
-  self.socket.on('error', noop) // ignore all future errors
-  try {
-    self.socket.destroy(cb)
-  } catch (err) {
-    cb(null)
+  if (socketPool[self.announceUrl].consumers === 0) {
+    delete socketPool[self.announceUrl]
+
+    self.socket.on('error', noop) // ignore all future errors
+
+    try {
+      self.socket.destroy(onclose)
+    } catch (err) {
+      if (onclose) onclose()
+    }
   }
 
   self.socket = null
@@ -122,7 +127,10 @@ WebSocketTracker.prototype._openSocket = function () {
   self.socket = socketPool[self.announceUrl]
   if (!self.socket) {
     self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl)
+    self.socket.consumers = 1
     self.socket.on('connect', self._onSocketConnectBound)
+  } else {
+    socketPool[self.announceUrl].consumers++
   }
 
   self.socket.on('data', self._onSocketDataBound)

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -149,9 +149,9 @@ WebSocketTracker.prototype._onSocketData = function (data) {
     return
   }
 
-  if (data.action === common.ACTIONS.ANNOUNCE || data.offer || data.answer) {
+  if (data.action === 'announce' || data.offer || data.answer) {
     self._onAnnounceResponse(data)
-  } else if (data.action === common.ACTIONS.SCRAPE) {
+  } else if (data.action === 'scrape') {
     self._onScrapeResponse(data)
   } else {
     throw new Error('invalid action in WS response: ' + data.action)
@@ -245,9 +245,7 @@ WebSocketTracker.prototype._onAnnounceResponse = function (data) {
 
 WebSocketTracker.prototype._onScrapeResponse = function (data) {
   var self = this
-  // NOTE: the unofficial spec says to use the 'files' key, 'host' has been
-  // seen in practice
-  data = data.files || data.host || {}
+  data = data.files || {}
 
   var keys = Object.keys(data)
   if (keys.length === 0) {

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -87,6 +87,7 @@ WebSocketTracker.prototype.destroy = function (cb) {
   if (self.destroyed) return cb(null)
   self.destroyed = true
   clearInterval(self.interval)
+  clearTimeout(self.reconnectTimer)
 
   if (socketPool[self.announceUrl]) socketPool[self.announceUrl].consumers--
 
@@ -303,7 +304,7 @@ WebSocketTracker.prototype._startReconnectTimer = function () {
     self.retries++
     self._openSocket()
   }, ms)
-  if (reconnectTimer.unref) reconnectTimer.unref()
+  if (self.reconnectTimer.unref) self.reconnectTimer.unref()
 
   debug('reconnecting socket in %s ms', ms)
 }

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -64,9 +64,10 @@ WebSocketTracker.prototype.scrape = function (opts) {
   self._onSocketError(new Error('scrape not supported ' + self.announceUrl))
 }
 
-WebSocketTracker.prototype.destroy = function (onclose) {
+WebSocketTracker.prototype.destroy = function (cb) {
   var self = this
-  if (self.destroyed) return onclose && onclose()
+  if (!cb) cb = noop
+  if (self.destroyed) return cb(null)
   self.destroyed = true
   clearInterval(self.interval)
 
@@ -84,9 +85,9 @@ WebSocketTracker.prototype.destroy = function (onclose) {
 
   self.socket.on('error', noop) // ignore all future errors
   try {
-    self.socket.destroy(onclose)
+    self.socket.destroy(cb)
   } catch (err) {
-    if (onclose) onclose()
+    cb(null)
   }
 
   self.socket = null

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -154,7 +154,7 @@ WebSocketTracker.prototype._onSocketData = function (data) {
   } else if (data.action === 'scrape') {
     self._onScrapeResponse(data)
   } else {
-    throw new Error('invalid action in WS response: ' + data.action)
+    self._onSocketError(new Error('invalid action in WS response: ' + data.action))
   }
 }
 

--- a/lib/server/parse-websocket.js
+++ b/lib/server/parse-websocket.js
@@ -8,7 +8,7 @@ function parseWebSocketRequest (socket, opts, params) {
 
   params.type = 'ws'
   params.socket = socket
-  if (params.action === 'announce' || params.answer || params.offers) {
+  if (params.action === 'announce' || params.offers || params.answer) {
     params.action = common.ACTIONS.ANNOUNCE
 
     if (typeof params.info_hash !== 'string' || params.info_hash.length !== 20) {
@@ -45,8 +45,6 @@ function parseWebSocketRequest (socket, opts, params) {
         }
         return common.binaryToHex(binaryInfoHash)
       })
-    } else {
-      params.info_hash = common.binaryToHex(params.info_hash)
     }
   } else {
     throw new Error('invalid action in WS request: ' + params.action)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "magnet-uri": "^5.0.0",
     "parse-torrent": "^5.0.0",
     "standard": "^6.0.4",
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "wrtc": "0.0.59"
   },
   "keywords": [
     "bittorrent",

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
+    "electron-webrtc": "^0.1.0",
     "magnet-uri": "^5.0.0",
     "parse-torrent": "^5.0.0",
     "standard": "^6.0.4",
-    "tape": "^4.0.0",
-    "wrtc": "0.0.59"
+    "tape": "^4.0.0"
   },
   "keywords": [
     "bittorrent",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bittorrent-tracker",
   "description": "Simple, robust, BitTorrent tracker (client & server) implementation",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bittorrent-tracker",
   "description": "Simple, robust, BitTorrent tracker (client & server) implementation",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bittorrent-tracker",
   "description": "Simple, robust, BitTorrent tracker (client & server) implementation",
-  "version": "7.4.1",
+  "version": "7.5.0",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bittorrent-tracker",
   "description": "Simple, robust, BitTorrent tracker (client & server) implementation",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/server.js
+++ b/server.js
@@ -599,6 +599,7 @@ Server.prototype._onWebSocketClose = function (socket) {
     var swarm = self.torrents[infoHash]
     if (swarm) {
       swarm.announce({
+        type: 'ws',
         event: 'stopped',
         numwant: 0,
         peer_id: socket.peerId

--- a/server.js
+++ b/server.js
@@ -353,8 +353,8 @@ Server.prototype._onWebSocketRequest = function (socket, opts, params) {
     socket.send(JSON.stringify(response), socket.onSend)
     debug('sent response %s to %s', JSON.stringify(response), params.peer_id)
 
-    if (params.numwant) {
-      debug('got offers %s from %s', JSON.stringify(params.offers), params.peer_id)
+    if (params.offers) {
+      debug('got offers %o from %s', params.offers, params.peer_id)
       debug('got %s peers from swarm %s', peers.length, params.info_hash)
       peers.forEach(function (peer, i) {
         peer.socket.send(JSON.stringify({

--- a/test/server.js
+++ b/test/server.js
@@ -1,7 +1,11 @@
 var Client = require('../')
 var common = require('./common')
 var test = require('tape')
-var wrtc = require('wrtc')
+var wrtc
+test('create daemon', (t) => {
+  wrtc = require('electron-webrtc')()
+  wrtc.electronDaemon.once('ready', t.end)
+})
 
 var infoHash = '4cb67059ed6bd08362da625b3ae77f6f4a075705'
 var peerId = new Buffer('01234567890123456789')
@@ -117,6 +121,12 @@ function serverTest (t, serverType, serverFamily) {
 
 test('websocket server', function (t) {
   serverTest(t, 'ws', 'inet')
+})
+
+// cleanup
+test('cleanup electron-eval daemon', (t) => {
+  wrtc.close()
+  t.end()
 })
 
 test('http ipv4 server', function (t) {


### PR DESCRIPTION
This PR attempts to add the websocket tracker to the test suite. 
It is based on my scrape implementation (PR #125) because it is one required in the existing test case and the addition of the wrtc package (sorry about that).

I improved the closing of the websocket tracker in the client to prevent hanging at the end of the case but there are still 2 sockets running and I cannot get rid of it.

I believe the remaining socket are between the peers (because it does not happens for one peer) but I can achieve to find it.

I use the command `wtfnode test/server.js`  to show the opened resources after the end of the test and I shows:

```
ok 100 should be equal
^C[WTF Node?] open handles:
- Sockets:
  - undefined:undefined -> undefined:undefined
    - Listeners:
  - undefined:undefined -> undefined:undefined
    - Listeners:

1..100
# tests 100
# pass  100

# ok
```

I leave this PR to get some help from you.
Any though?