### PR TITLE
Add testing for websocket server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
   - "node"
   - "4"
   - "0.12"
+before_script:
+  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -88,7 +88,7 @@ WebSocketTracker.prototype.destroy = function (cb) {
   self.destroyed = true
   clearInterval(self.interval)
 
-  delete socketPool[self.announceUrl]
+  if (socketPool[self.announceUrl]) socketPool[self.announceUrl].consumers--
 
   self.socket.removeListener('connect', self._onSocketConnectBound)
   self.socket.removeListener('data', self._onSocketDataBound)
@@ -100,11 +100,16 @@ WebSocketTracker.prototype.destroy = function (cb) {
   self._onSocketDataBound = null
   self._onSocketCloseBound = null
 
-  self.socket.on('error', noop) // ignore all future errors
-  try {
-    self.socket.destroy(cb)
-  } catch (err) {
-    cb(null)
+  if (socketPool[self.announceUrl].consumers === 0) {
+    delete socketPool[self.announceUrl]
+
+    self.socket.on('error', noop) // ignore all future errors
+
+    try {
+      self.socket.destroy(cb)
+    } catch (err) {
+      if (cb) cb()
+    }
   }
 
   self.socket = null
@@ -122,7 +127,10 @@ WebSocketTracker.prototype._openSocket = function () {
   self.socket = socketPool[self.announceUrl]
   if (!self.socket) {
     self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl)
+    self.socket.consumers = 1
     self.socket.on('connect', self._onSocketConnectBound)
+  } else {
+    socketPool[self.announceUrl].consumers++
   }
 
   self.socket.on('data', self._onSocketDataBound)

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -89,6 +89,15 @@ WebSocketTracker.prototype.destroy = function (cb) {
   clearInterval(self.interval)
   clearTimeout(self.reconnectTimer)
 
+  // Destroy peers
+  for(var peerId in self.peers) {
+    var peer = self.peers[peerId]
+    clearTimeout(peer.trackerTimeout)
+    peer.destroy()
+  }
+  delete self.peers
+
+  // Close socked
   if (socketPool[self.announceUrl]) socketPool[self.announceUrl].consumers--
 
   self.socket.removeListener('connect', self._onSocketConnectBound)

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -90,7 +90,7 @@ WebSocketTracker.prototype.destroy = function (cb) {
   clearTimeout(self.reconnectTimer)
 
   // Destroy peers
-  for(var peerId in self.peers) {
+  for (var peerId in self.peers) {
     var peer = self.peers[peerId]
     clearTimeout(peer.trackerTimeout)
     peer.destroy()

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -87,6 +87,7 @@ WebSocketTracker.prototype.destroy = function (cb) {
   if (self.destroyed) return cb(null)
   self.destroyed = true
   clearInterval(self.interval)
+  clearTimeout(self.reconnectTimer)
 
   if (socketPool[self.announceUrl]) socketPool[self.announceUrl].consumers--
 
@@ -299,11 +300,11 @@ WebSocketTracker.prototype._startReconnectTimer = function () {
   var ms = Math.floor(Math.random() * RECONNECT_VARIANCE) + Math.min(Math.pow(2, self.retries) * RECONNECT_MINIMUM, RECONNECT_MAXIMUM)
 
   self.reconnecting = true
-  var reconnectTimer = setTimeout(function () {
+  self.reconnectTimer = setTimeout(function () {
     self.retries++
     self._openSocket()
   }, ms)
-  if (reconnectTimer.unref) reconnectTimer.unref()
+  if (self.reconnectTimer.unref) self.reconnectTimer.unref()
 
   debug('reconnecting socket in %s ms', ms)
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
+    "electron-webrtc": "^0.1.0",
     "magnet-uri": "^5.0.0",
     "parse-torrent": "^5.0.0",
     "standard": "^6.0.4",

--- a/server.js
+++ b/server.js
@@ -599,6 +599,7 @@ Server.prototype._onWebSocketClose = function (socket) {
     var swarm = self.torrents[infoHash]
     if (swarm) {
       swarm.announce({
+        type: 'ws',
         event: 'stopped',
         numwant: 0,
         peer_id: socket.peerId

--- a/test/server.js
+++ b/test/server.js
@@ -1,6 +1,7 @@
 var Client = require('../')
 var common = require('./common')
 var test = require('tape')
+var wrtc
 
 var infoHash = '4cb67059ed6bd08362da625b3ae77f6f4a075705'
 var peerId = new Buffer('01234567890123456789')
@@ -25,7 +26,7 @@ function serverTest (t, serverType, serverFamily) {
       infoHash: infoHash,
       length: torrentLength,
       announce: [ announceUrl ]
-    })
+    }, { wrtc: wrtc })
 
     client1.start()
 
@@ -45,14 +46,19 @@ function serverTest (t, serverType, serverFamily) {
         t.equal(swarm.complete, 0)
         t.equal(swarm.incomplete, 1)
         t.equal(Object.keys(swarm.peers).length, 1)
-        t.deepEqual(swarm.peers[hostname + ':6881'], {
-          type: serverType,
-          ip: clientIp,
-          port: 6881,
-          peerId: peerId.toString('hex'),
-          complete: false,
-          socket: undefined
-        })
+
+        if (serverType !== 'ws') {
+          t.deepEqual(swarm.peers[hostname + ':6881'], {
+            type: serverType,
+            ip: clientIp,
+            port: 6881,
+            peerId: peerId.toString('hex'),
+            complete: false,
+            socket: undefined
+          })
+        } else {
+          t.equal(swarm.peers[peerId.toString('hex')].complete, false)
+        }
 
         client1.complete()
 
@@ -73,7 +79,7 @@ function serverTest (t, serverType, serverFamily) {
               infoHash: infoHash,
               length: torrentLength,
               announce: [ announceUrl ]
-            })
+            }, { wrtc: wrtc })
 
             client2.start()
 
@@ -82,7 +88,7 @@ function serverTest (t, serverType, serverFamily) {
             })
 
             client2.once('peer', function (addr) {
-              t.ok(addr === hostname + ':6881' || addr === hostname + ':6882')
+              t.ok(addr === hostname + ':6881' || addr === hostname + ':6882' || addr.id === peerId.toString('hex'))
 
               client2.stop()
               client2.once('update', function (data) {
@@ -108,6 +114,21 @@ function serverTest (t, serverType, serverFamily) {
     })
   })
 }
+
+test('create daemon', function (t) {
+  wrtc = require('electron-webrtc')()
+  wrtc.electronDaemon.once('ready', t.end)
+})
+
+test('websocket server', function (t) {
+  serverTest(t, 'ws', 'inet')
+})
+
+// cleanup
+test('cleanup electron-eval daemon', function (t) {
+  wrtc.close()
+  t.end()
+})
 
 test('http ipv4 server', function (t) {
   serverTest(t, 'http', 'inet')


### PR DESCRIPTION
This PR adds the websocket tracker to the test suite. 
It is based on my scrape implementation (PR #125) because it is one required in the existing test case and the addition of the electron-webrtc package.

I improved the closing of the websocket tracker in the client to prevent hanging at the end of the case.