### PR TITLE
reset initial values on destroy

### DIFF
--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -94,6 +94,7 @@ WebSocketTracker.prototype.destroy = function (cb) {
   self.destroyed = true
   clearInterval(self.interval)
   clearTimeout(self.reconnectTimer)
+  self.reconnectTimer = null
 
   self.socket.removeListener('connect', self._onSocketConnectBound)
   self.socket.removeListener('data', self._onSocketDataBound)
@@ -111,7 +112,7 @@ WebSocketTracker.prototype.destroy = function (cb) {
     clearTimeout(peer.trackerTimeout)
     peer.destroy()
   }
-  self.peers = null
+  self.peers = {}
 
   if (socketPool[self.announceUrl]) {
     socketPool[self.announceUrl].consumers -= 1
@@ -130,6 +131,8 @@ WebSocketTracker.prototype.destroy = function (cb) {
   }
 
   self.socket = null
+  self.reconnecting = false
+  self.retries = 0
 }
 
 WebSocketTracker.prototype._openSocket = function () {


### PR DESCRIPTION
As a `WebsocketTracker` is destroyed and reconnects after the specified/default interval some initial values are removed (which causes an errors e.g. as [.peers is not an object anymore](https://github.com/feross/bittorrent-tracker/blob/master/lib/client/websocket-tracker.js#L350)).