### PR TITLE
buffer-equals instead buffer-equal

### DIFF
--- a/lib/server/parse-udp.js
+++ b/lib/server/parse-udp.js
@@ -1,6 +1,6 @@
 module.exports = parseUdpRequest
 
-var bufferEqual = require('buffer-equal')
+var bufferEquals = require('buffer-equals')
 var ipLib = require('ip')
 var common = require('../common')
 
@@ -14,7 +14,7 @@ function parseUdpRequest (msg, rinfo) {
     type: 'udp'
   }
 
-  if (!bufferEqual(params.connectionId, common.CONNECTION_ID)) {
+  if (!bufferEquals(params.connectionId, common.CONNECTION_ID)) {
     throw new Error('received packet with invalid connection id')
   }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bencode": "^0.7.0",
     "bn.js": "^4.4.0",
-    "buffer-equal": "^1.0.0",
+    "buffer-equals": "^1.0.3",
     "compact2string": "^1.2.0",
     "debug": "^2.0.0",
     "hat": "0.0.3",


### PR DESCRIPTION
[buffer-equal](https://github.com/substack/node-buffer-equal/blob/76c6545022bf211eb6305d9c4b8c37628029f7f7/index.js#L3) not throwing `TypeError` if one of arguments is not `Buffer`, but node buffer equals does.
[buffer-equals](https://github.com/sindresorhus/buffer-equals/blob/7eff8317ce92d075db1bfa79cec2390ed273e5e7/index.js#L4) throwing `TypeError`

This PR is useless for current code, but I think it will be right use function with right behavior.