### PR TITLE
Re-enabled wrtc server tests, using SIGKILL to ensure Electron daemon gets killed

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -1,12 +1,12 @@
 var Client = require('../')
 var common = require('./common')
 var test = require('tape')
-// var wrtc = require('electron-webrtc')()
+var wrtc = require('electron-webrtc')()
 
-// var wrtcReady = false
-// wrtc.electronDaemon.once('ready', function () {
-//   wrtcReady = true
-// })
+var wrtcReady = false
+wrtc.electronDaemon.once('ready', function () {
+  wrtcReady = true
+})
 
 var infoHash = '4cb67059ed6bd08362da625b3ae77f6f4a075705'
 var peerId = new Buffer('01234567890123456789')
@@ -31,7 +31,7 @@ function serverTest (t, serverType, serverFamily) {
       infoHash: infoHash,
       length: torrentLength,
       announce: [ announceUrl ]
-    }/*, { wrtc: wrtc }*/)
+    }, { wrtc: wrtc })
 
     client1.start()
 
@@ -87,7 +87,7 @@ function serverTest (t, serverType, serverFamily) {
               infoHash: infoHash,
               length: torrentLength,
               announce: [ announceUrl ]
-            }/*, { wrtc: wrtc }*/)
+            }, { wrtc: wrtc })
 
             client2.start()
 
@@ -113,7 +113,7 @@ function serverTest (t, serverType, serverFamily) {
 
                   client1.destroy()
                   server.close()
-                  // if (serverType === 'ws') wrtc.close()
+                  if (serverType === 'ws') wrtc.close('SIGKILL')
                 })
               })
             })
@@ -124,16 +124,16 @@ function serverTest (t, serverType, serverFamily) {
   })
 }
 
-// test('websocket server', function (t) {
-//   if (wrtcReady) {
-//     runTest()
-//   } else {
-//     wrtc.electronDaemon.once('ready', runTest)
-//   }
-//   function runTest () {
-//     serverTest(t, 'ws', 'inet')
-//   }
-// })
+test('websocket server', function (t) {
+  if (wrtcReady) {
+    runTest()
+  } else {
+    wrtc.electronDaemon.once('ready', runTest)
+  }
+  function runTest () {
+    serverTest(t, 'ws', 'inet')
+  }
+})
 
 test('http ipv4 server', function (t) {
   serverTest(t, 'http', 'inet')


### PR DESCRIPTION
The tests close correctly on Linux now, since we ensure Electron closes by sending it a SIGKILL signal. I'm still not sure what's keeping it open, but it might make sense to just use SIGKILL by default in `electron-eval`. (Would you rather I make that change and just update the dependency here?)