### PR TITLE
Use safe-buffer

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,5 +1,6 @@
 module.exports = Client
 
+var Buffer = require('safe-buffer').Buffer
 var debug = require('debug')('bittorrent-tracker')
 var EventEmitter = require('events').EventEmitter
 var extend = require('xtend')
@@ -46,13 +47,13 @@ function Client (opts) {
   self.peerId = typeof opts.peerId === 'string'
     ? opts.peerId
     : opts.peerId.toString('hex')
-  self._peerIdBuffer = new Buffer(self.peerId, 'hex')
+  self._peerIdBuffer = Buffer.from(self.peerId, 'hex')
   self._peerIdBinary = self._peerIdBuffer.toString('binary')
 
   self.infoHash = typeof opts.infoHash === 'string'
     ? opts.infoHash
     : opts.infoHash.toString('hex')
-  self._infoHashBuffer = new Buffer(self.infoHash, 'hex')
+  self._infoHashBuffer = Buffer.from(self.infoHash, 'hex')
   self._infoHashBinary = self._infoHashBuffer.toString('binary')
 
   self._port = opts.port
@@ -131,7 +132,7 @@ Client.scrape = function (opts, cb) {
 
   var clientOpts = extend(opts, {
     infoHash: Array.isArray(opts.infoHash) ? opts.infoHash[0] : opts.infoHash,
-    peerId: new Buffer('01234567890123456789'), // dummy value
+    peerId: Buffer.from('01234567890123456789'), // dummy value
     port: 6881 // dummy value
   })
 
@@ -156,9 +157,9 @@ Client.scrape = function (opts, cb) {
 
   opts.infoHash = Array.isArray(opts.infoHash)
     ? opts.infoHash.map(function (infoHash) {
-      return new Buffer(String(infoHash), 'hex')
+      return Buffer.from(infoHash, 'hex')
     })
-    : new Buffer(String(opts.infoHash), 'hex')
+    : Buffer.from(opts.infoHash, 'hex')
   client.scrape({ infoHash: opts.infoHash })
   return client
 }

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -1,6 +1,7 @@
 module.exports = UDPTracker
 
 var BN = require('bn.js')
+var Buffer = require('safe-buffer').Buffer
 var compact2string = require('compact2string')
 var debug = require('debug')('bittorrent-tracker:udp-tracker')
 var dgram = require('dgram')
@@ -196,7 +197,7 @@ UDPTracker.prototype._request = function (opts) {
       self.client._infoHashBuffer,
       self.client._peerIdBuffer,
       toUInt64(opts.downloaded),
-      opts.left != null ? toUInt64(opts.left) : new Buffer('FFFFFFFFFFFFFFFF', 'hex'),
+      opts.left != null ? toUInt64(opts.left) : Buffer.from('FFFFFFFFFFFFFFFF', 'hex'),
       toUInt64(opts.uploaded),
       common.toUInt32(common.EVENTS[opts.event] || 0),
       common.toUInt32(0), // ip address (optional)
@@ -223,11 +224,11 @@ UDPTracker.prototype._request = function (opts) {
 }
 
 function genTransactionId () {
-  return new Buffer(hat(32), 'hex')
+  return Buffer.from(hat(32), 'hex')
 }
 
 function toUInt16 (n) {
-  var buf = new Buffer(2)
+  var buf = Buffer.allocUnsafe(2)
   buf.writeUInt16BE(n, 0)
   return buf
 }
@@ -240,7 +241,7 @@ function toUInt64 (n) {
     while (bytes.length < 8) {
       bytes.unshift(0)
     }
-    return new Buffer(bytes)
+    return Buffer.from(bytes)
   }
   return Buffer.concat([common.toUInt32(0), common.toUInt32(n)])
 }

--- a/lib/common-node.js
+++ b/lib/common-node.js
@@ -3,6 +3,7 @@
  * These are separate from common.js so they can be skipped when bundling for the browser.
  */
 
+var Buffer = require('safe-buffer').Buffer
 var querystring = require('querystring')
 
 exports.IPV4_RE = /^[\d\.]+$/
@@ -26,7 +27,7 @@ exports.EVENT_NAMES = {
 }
 
 function toUInt32 (n) {
-  var buf = new Buffer(4)
+  var buf = Buffer.allocUnsafe(4)
   buf.writeUInt32BE(n, 0)
   return buf
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -2,17 +2,24 @@
  * Functions/constants needed by both the client and server.
  */
 
+var Buffer = require('safe-buffer').Buffer
 var extend = require('xtend/mutable')
 
 exports.DEFAULT_ANNOUNCE_PEERS = 50
 exports.MAX_ANNOUNCE_PEERS = 82
 
 exports.binaryToHex = function (str) {
-  return new Buffer(str, 'binary').toString('hex')
+  if (typeof str !== 'string') {
+    str = String(str)
+  }
+  return Buffer.from(str, 'binary').toString('hex')
 }
 
 exports.hexToBinary = function (str) {
-  return new Buffer(str, 'hex').toString('binary')
+  if (typeof str !== 'string') {
+    str = String(str)
+  }
+  return Buffer.from(str, 'hex').toString('binary')
 }
 
 var config = require('./common-node')

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "random-iterate": "^1.0.1",
     "run-parallel": "^1.1.2",
     "run-series": "^1.0.2",
+    "safe-buffer": "^5.0.0",
     "simple-get": "^2.0.0",
     "simple-peer": "^6.0.0",
     "simple-websocket": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/feross/bittorrent-tracker/issues"
   },
   "dependencies": {
-    "bencode": "^0.9.0",
+    "bencode": "^0.10.0",
     "bn.js": "^4.4.0",
     "compact2string": "^1.2.0",
     "debug": "^2.0.0",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 module.exports = Server
 
+var Buffer = require('safe-buffer').Buffer
 var bencode = require('bencode')
 var debug = require('debug')('bittorrent-tracker')
 var dgram = require('dgram')
@@ -674,7 +675,7 @@ function makeUdpPacket (params) {
       packet = Buffer.concat([
         common.toUInt32(common.ACTIONS.ERROR),
         common.toUInt32(params.transactionId || 0),
-        new Buffer(params['failure reason'], 'utf8')
+        Buffer.from(String(params['failure reason']))
       ])
       break
     default:

--- a/test/client-large-torrent.js
+++ b/test/client-large-torrent.js
@@ -1,9 +1,10 @@
+var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
 
-var peerId = new Buffer('01234567890123456789')
+var peerId = Buffer.from('01234567890123456789')
 
 function testLargeTorrent (t, serverType) {
   t.plan(9)

--- a/test/client-magnet.js
+++ b/test/client-magnet.js
@@ -1,10 +1,11 @@
+var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var fixtures = require('webtorrent-fixtures')
 var magnet = require('magnet-uri')
 var test = require('tape')
 
-var peerId = new Buffer('01234567890123456789')
+var peerId = Buffer.from('01234567890123456789')
 
 function testMagnet (t, serverType) {
   t.plan(9)

--- a/test/client-ws-socket-pool.js
+++ b/test/client-ws-socket-pool.js
@@ -1,9 +1,10 @@
+var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
 
-var peerId = new Buffer('01234567890123456789')
+var peerId = Buffer.from('01234567890123456789')
 var port = 6681
 
 test('ensure client.destroy() callback is called with re-used websockets in socketPool', function (t) {

--- a/test/client.js
+++ b/test/client.js
@@ -1,11 +1,12 @@
+var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
 
-var peerId1 = new Buffer('01234567890123456789')
-var peerId2 = new Buffer('12345678901234567890')
-var peerId3 = new Buffer('23456789012345678901')
+var peerId1 = Buffer.from('01234567890123456789')
+var peerId2 = Buffer.from('12345678901234567890')
+var peerId3 = Buffer.from('23456789012345678901')
 var port = 6881
 
 function testClientStart (t, serverType) {

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,9 +1,10 @@
+var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
 
-var peerId = new Buffer('01234567890123456789')
+var peerId = Buffer.from('01234567890123456789')
 
 function testFilterOption (t, serverType) {
   t.plan(8)

--- a/test/querystring.js
+++ b/test/querystring.js
@@ -1,10 +1,11 @@
+var Buffer = require('safe-buffer').Buffer
 var common = require('../lib/common')
 var test = require('tape')
 
 // https://github.com/feross/webtorrent/issues/196
 test('encode special chars +* in http tracker urls', function (t) {
   var q = {
-    info_hash: new Buffer('a2a15537542b22925ad10486bf7a8b2a9c42f0d1', 'hex').toString('binary')
+    info_hash: Buffer.from('a2a15537542b22925ad10486bf7a8b2a9c42f0d1', 'hex').toString('binary')
   }
   var encoded = 'info_hash=%A2%A1U7T%2B%22%92Z%D1%04%86%BFz%8B%2A%9CB%F0%D1'
   t.equal(common.querystringStringify(q), encoded)

--- a/test/scrape.js
+++ b/test/scrape.js
@@ -1,4 +1,5 @@
 var bencode = require('bencode')
+var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var commonLib = require('../lib/common')
@@ -7,7 +8,7 @@ var fixtures = require('webtorrent-fixtures')
 var get = require('simple-get')
 var test = require('tape')
 
-var peerId = new Buffer('01234567890123456789')
+var peerId = Buffer.from('01234567890123456789')
 
 function testSingle (t, serverType) {
   commonTest.createServer(t, serverType, function (server, announceUrl) {

--- a/test/server.js
+++ b/test/server.js
@@ -1,3 +1,4 @@
+var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var test = require('tape')
@@ -9,8 +10,8 @@ var test = require('tape')
 // })
 
 var infoHash = '4cb67059ed6bd08362da625b3ae77f6f4a075705'
-var peerId = new Buffer('01234567890123456789')
-var peerId2 = new Buffer('12345678901234567890')
+var peerId = Buffer.from('01234567890123456789')
+var peerId2 = Buffer.from('12345678901234567890')
 
 function serverTest (t, serverType, serverFamily) {
   t.plan(30)


### PR DESCRIPTION
Use the new Buffer APIs from Node v6 for added security. For example,
`Buffer.from()` will throw if passed a number, unlike `Buffer()` which
allocated UNINITIALIZED memory in that case.

Use the `safe-buffer` package for compatibility with previous versions
of Node.js, including v4.x, v0.12, and v0.10.

https://github.com/feross/safe-buffer