### PR TITLE
Check if peek(peerId) is undefined

### DIFF
--- a/server.js
+++ b/server.js
@@ -198,28 +198,33 @@ function Server (opts) {
           if (keys.length > 0) activeTorrents++
 
           keys.forEach(function (peerId) {
-            if (!allPeers.hasOwnProperty(peerId)) {
-              allPeers[peerId] = {
-                ipv4: false,
-                ipv6: false,
-                seeder: false,
-                leecher: false
-              }
-            }
             // Don't mark the peer as most recently used for stats
             var peer = peers.peek(peerId)
-            if (peer.ip.indexOf(':') >= 0) {
-              allPeers[peerId].ipv6 = true
-            } else {
-              allPeers[peerId].ipv4 = true
+
+            // The peer could be evicted at this point
+            if (typeof peer !== 'undefined') {
+              if (!allPeers.hasOwnProperty(peerId)) {
+                allPeers[peerId] = {
+                  ipv4: false,
+                  ipv6: false,
+                  seeder: false,
+                  leecher: false
+                }
+              }
+
+              if (peer.ip.indexOf(':') >= 0) {
+                allPeers[peerId].ipv6 = true
+              } else {
+                allPeers[peerId].ipv4 = true
+              }
+              if (peer.complete) {
+                allPeers[peerId].seeder = true
+              } else {
+                allPeers[peerId].leecher = true
+              }
+              allPeers[peerId].peerId = peer.peerId
+              allPeers[peerId].client = peerid(peer.peerId)
             }
-            if (peer.complete) {
-              allPeers[peerId].seeder = true
-            } else {
-              allPeers[peerId].leecher = true
-            }
-            allPeers[peerId].peerId = peer.peerId
-            allPeers[peerId].client = peerid(peer.peerId)
           })
         })
 


### PR DESCRIPTION
`Object.keys()` creates a new array, so while iterating through those keys, one of the peers could have been evicted from the cache. This makes `peek(peerId)` return `undefined`.