### PR TITLE
Fix issue where seeders improperly marked as leechers

### DIFF
--- a/lib/server/parse-http.js
+++ b/lib/server/parse-http.js
@@ -24,7 +24,9 @@ function parseHttpRequest (req, opts) {
     params.port = Number(params.port)
     if (!params.port) throw new Error('invalid port')
 
-    params.left = Number(params.left) || Infinity
+    params.left = Number(params.left)
+    if (isNaN(params.left)) params.left = Infinity
+
     params.compact = Number(params.compact) || 0
     params.numwant = Math.min(
       Number(params.numwant) || common.DEFAULT_ANNOUNCE_PEERS,


### PR DESCRIPTION
This fixes an issue I was running into with traditional BitTorrent clients. The tracker was marking seeders as leechers, even though this was not the case.

When starting a new transfer with all of the files already downloaded, a `started` event is sent out with `left=0` (at least this is the case in Deluge and Transmission). A `completed` event is explicitly **not** sent out (FTA https://wiki.theory.org/BitTorrentSpecification):

> `completed`: Must be sent to the tracker when the download completes. **However, must not be sent if the download was already 100% complete when the client started.** Presumably, this is to allow the tracker to increment the "completed downloads" metric based solely on this event.

Currently params.left is set to `Infinity` even if it was supplied as `left=0` in the querystring. This fixes that issue, and retains the behavior of setting `params.left` to Infinity when it is unparseable.
