### PR TITLE
update time to cleanup sooner

### DIFF
--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -82,7 +82,7 @@ UDPTracker.prototype._request = function (opts) {
   self.cleanupFns.push(cleanup)
 
   // does not matter if `stopped` event arrives, so supress errors & cleanup after timeout
-  var ms = opts.event === 'stopped' ? TIMEOUT / 10 : TIMEOUT
+  var ms = opts.event === 'stopped' ? TIMEOUT / 20 : TIMEOUT
   var timeout = setTimeout(function () {
     timeout = null
     if (opts.event === 'stopped') cleanup()


### PR DESCRIPTION
For the sake of sending an EVENT 3 (stop announce), it's best to remove a destroy action up the chain of command. This ensures a quick cleanup after 'stopped' is submitted.