### PR TITLE
ws client: Don't include offers with 'completed' event

### DIFF
--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -60,8 +60,8 @@ WebSocketTracker.prototype.announce = function (opts) {
   })
   if (self._trackerId) params.trackerid = self._trackerId
 
-  if (opts.event === 'stopped') {
-    // Don't include offers with 'stopped' event
+  if (opts.event === 'stopped' || opts.event === 'completed') {
+    // Don't include offers with 'stopped' or 'completed' event
     self._send(params)
   } else {
     // Limit the number of offers that are generated, since it can be slow


### PR DESCRIPTION
It's not necessary to include webrtc offers because the client is not
really looking for more peers when it has just completed the torrent.

Fewer WebRTC offers = less resource usage