### PR TITLE
Fix stats and leaked websockets

### DIFF
--- a/client.js
+++ b/client.js
@@ -69,6 +69,11 @@ function Client (opts) {
   // See: https://github.com/feross/webtorrent-hybrid/issues/46
   self._wrtc = typeof opts.wrtc === 'function' ? opts.wrtc() : opts.wrtc
 
+  // Use a socket pool, so WebSocket tracker clients share WebSocket objects for
+  // the same server. In practice, WebSockets are pretty slow to establish, so this
+  // gives a nice performance boost, and saves browser resources.
+  self._socketPool = {}
+
   var announce = typeof opts.announce === 'string'
     ? [ opts.announce ]
     : opts.announce == null ? [] : opts.announce

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -10,11 +10,6 @@ var Socket = require('simple-websocket')
 var common = require('../common')
 var Tracker = require('./tracker')
 
-// Use a socket pool, so tracker clients share WebSocket objects for the same server.
-// In practice, WebSockets are pretty slow to establish, so this gives a nice performance
-// boost, and saves browser resources.
-var socketPool = {}
-
 var RECONNECT_MINIMUM = 15 * 1000
 var RECONNECT_MAXIMUM = 30 * 60 * 1000
 var RECONNECT_VARIANCE = 30 * 1000
@@ -129,15 +124,15 @@ WebSocketTracker.prototype.destroy = function (cb) {
   self._onSocketDataBound = null
   self._onSocketCloseBound = null
 
-  if (socketPool[self.announceUrl]) {
-    socketPool[self.announceUrl].consumers -= 1
+  if (self.client._socketPool[self.announceUrl]) {
+    self.client._socketPool[self.announceUrl].consumers -= 1
   }
 
   // Other instances are using the socket, so there's nothing left to do here
-  if (socketPool[self.announceUrl].consumers > 0) return cb()
+  if (self.client._socketPool[self.announceUrl].consumers > 0) return cb()
 
-  var socket = socketPool[self.announceUrl]
-  delete socketPool[self.announceUrl]
+  var socket = self.client._socketPool[self.announceUrl]
+  delete self.client._socketPool[self.announceUrl]
   socket.on('error', noop) // ignore all future errors
   socket.once('close', cb)
 
@@ -182,11 +177,11 @@ WebSocketTracker.prototype._openSocket = function () {
     self._onSocketClose()
   }
 
-  self.socket = socketPool[self.announceUrl]
+  self.socket = self.client._socketPool[self.announceUrl]
   if (self.socket) {
-    socketPool[self.announceUrl].consumers += 1
+    self.client._socketPool[self.announceUrl].consumers += 1
   } else {
-    self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl)
+    self.socket = self.client._socketPool[self.announceUrl] = new Socket(self.announceUrl)
     self.socket.consumers = 1
     self.socket.once('connect', self._onSocketConnectBound)
   }

--- a/lib/server/parse-http.js
+++ b/lib/server/parse-http.js
@@ -25,7 +25,7 @@ function parseHttpRequest (req, opts) {
     if (!params.port) throw new Error('invalid port')
 
     params.left = Number(params.left)
-    if (isNaN(params.left)) params.left = Infinity
+    if (Number.isNaN(params.left)) params.left = Infinity
 
     params.compact = Number(params.compact) || 0
     params.numwant = Math.min(

--- a/lib/server/parse-websocket.js
+++ b/lib/server/parse-websocket.js
@@ -28,7 +28,9 @@ function parseWebSocketRequest (socket, opts, params) {
       params.to_peer_id = common.binaryToHex(params.to_peer_id)
     }
 
-    params.left = Number(params.left) || Infinity
+    params.left = Number(params.left)
+    if (Number.isNaN(params.left)) params.left = Infinity
+
     params.numwant = Math.min(
       Number(params.offers && params.offers.length) || 0, // no default - explicit only
       common.MAX_ANNOUNCE_PEERS

--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -7,19 +7,29 @@ var randomIterate = require('random-iterate')
 // Regard this as the default implementation of an interface that you
 // need to support when overriding Server.createSwarm() and Server.getSwarm()
 function Swarm (infoHash, server) {
+  this.infoHash = infoHash
   this.complete = 0
   this.incomplete = 0
+
   this.peers = new LRU({
     max: server.peersCacheLength || 1000,
     maxAge: server.peersCacheTtl || 20 * 60 * 1000 // 20 minutes
   })
 
-  // When a websocket peer is evicted from the LRU cache, close the websocket
-  // after a short timeout period. We wait 1s so the server has a chance to send
-  // a response to 'stopped' events, which remove the peer and cause an eviction.
+  // When a peer is evicted from the LRU store, send a synthetic 'stopped' event
+  // so the stats get updated correctly.
   this.peers.on('evict', function (data) {
     var peer = data.value
-    if (peer.socket) {
+    this.announce({
+      type: peer.type,
+      event: 'stopped',
+      numwant: 0,
+      peer_id: peer.peerId
+    }, noop)
+
+    // When a websocket peer is evicted, and it's not in any other swarms, close
+    // the websocket to conserve server resources.
+    if (peer.socket && peer.socket.infoHashes.length === 0) {
       try {
         peer.socket.close()
         peer.socket = null
@@ -86,6 +96,14 @@ Swarm.prototype._onAnnounceStopped = function (params, peer, id) {
 
   if (peer.complete) this.complete -= 1
   else this.incomplete -= 1
+
+  // If it's a websocket, remove this swarm's infohash from the list of active
+  // swarms that this peer is participating in.
+  if (peer.socket) {
+    var index = peer.socket.infoHashes.indexOf(this.infoHash)
+    peer.socket.infoHashes.splice(index, 1)
+  }
+
   this.peers.remove(id)
 }
 
@@ -133,3 +151,5 @@ Swarm.prototype._getPeers = function (numwant, ownPeerId, isWebRTC) {
   }
   return peers
 }
+
+function noop () {}

--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -14,15 +14,18 @@ function Swarm (infoHash, server) {
     maxAge: server.peersCacheTtl || 20 * 60 * 1000 // 20 minutes
   })
 
-  // When a peer is evicted from the LRU cache, if it's a websocket peer,
-  // close the websocket.
+  // When a websocket peer is evicted from the LRU cache, close the websocket
+  // after a short timeout period. We wait 1s so the server has a chance to send
+  // a response to 'stopped' events, which remove the peer and cause an eviction.
   this.peers.on('evict', function (data) {
     var peer = data.value
     if (peer.socket) {
-      try {
-        peer.socket.close()
-        peer.socket = null
-      } catch (err) {}
+      setTimeout(function () {
+        try {
+          peer.socket.close()
+          peer.socket = null
+        } catch (err) {}
+      }, 1000)
     }
   })
 }

--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -7,12 +7,24 @@ var randomIterate = require('random-iterate')
 // Regard this as the default implementation of an interface that you
 // need to support when overriding Server.createSwarm() and Server.getSwarm()
 function Swarm (infoHash, server) {
+  this.complete = 0
+  this.incomplete = 0
   this.peers = new LRU({
     max: server.peersCacheLength || 1000,
     maxAge: server.peersCacheTtl || 20 * 60 * 1000 // 20 minutes
   })
-  this.complete = 0
-  this.incomplete = 0
+
+  // When a peer is evicted from the LRU cache, if it's a websocket peer,
+  // close the websocket.
+  this.peers.on('evict', function (data) {
+    var peer = data.value
+    if (peer.socket) {
+      try {
+        peer.socket.close()
+        peer.socket = null
+      } catch (err) {}
+    }
+  })
 }
 
 Swarm.prototype.announce = function (params, cb) {

--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -102,8 +102,8 @@ Swarm.prototype._onAnnounceUpdate = function (params, peer, id) {
     this.complete += 1
     this.incomplete -= 1
     peer.complete = true
-    this.peers.set(id, peer)
   }
+  this.peers.set(id, peer)
 }
 
 Swarm.prototype._getPeers = function (numwant, ownPeerId, isWebRTC) {

--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -20,12 +20,10 @@ function Swarm (infoHash, server) {
   this.peers.on('evict', function (data) {
     var peer = data.value
     if (peer.socket) {
-      setTimeout(function () {
-        try {
-          peer.socket.close()
-          peer.socket = null
-        } catch (err) {}
-      }, 1000)
+      try {
+        peer.socket.close()
+        peer.socket = null
+      } catch (err) {}
     }
   })
 }

--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -82,8 +82,8 @@ Swarm.prototype._onAnnounceCompleted = function (params, peer, id) {
     return this._onAnnounceStarted(params, peer, id) // treat as a start
   }
   if (peer.complete) {
-    debug('unexpected `completed` event from peer that is already marked as completed')
-    return // do nothing
+    debug('unexpected `completed` event from peer that is already completed')
+    return this._onAnnounceUpdate(params, peer, id) // treat as an update
   }
 
   this.complete += 1

--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -9,7 +9,7 @@ var randomIterate = require('random-iterate')
 function Swarm (infoHash, server) {
   this.peers = new LRU({
     max: server.peersCacheLength || 1000,
-    maxAge: server.peersCacheTtl || 900000 // 900 000ms = 15 minutes
+    maxAge: server.peersCacheTtl || 20 * 60 * 1000 // 20 minutes
   })
   this.complete = 0
   this.incomplete = 0

--- a/lib/server/swarm.js
+++ b/lib/server/swarm.js
@@ -7,25 +7,27 @@ var randomIterate = require('random-iterate')
 // Regard this as the default implementation of an interface that you
 // need to support when overriding Server.createSwarm() and Server.getSwarm()
 function Swarm (infoHash, server) {
-  this.infoHash = infoHash
-  this.complete = 0
-  this.incomplete = 0
+  var self = this
+  self.infoHash = infoHash
+  self.complete = 0
+  self.incomplete = 0
 
-  this.peers = new LRU({
+  self.peers = new LRU({
     max: server.peersCacheLength || 1000,
     maxAge: server.peersCacheTtl || 20 * 60 * 1000 // 20 minutes
   })
 
   // When a peer is evicted from the LRU store, send a synthetic 'stopped' event
   // so the stats get updated correctly.
-  this.peers.on('evict', function (data) {
+  self.peers.on('evict', function (data) {
     var peer = data.value
-    this.announce({
+    var params = {
       type: peer.type,
       event: 'stopped',
       numwant: 0,
       peer_id: peer.peerId
-    }, noop)
+    }
+    self._onAnnounceStopped(params, peer, peer.peerId)
 
     // When a websocket peer is evicted, and it's not in any other swarms, close
     // the websocket to conserve server resources.
@@ -151,5 +153,3 @@ Swarm.prototype._getPeers = function (numwant, ownPeerId, isWebRTC) {
   }
   return peers
 }
-
-function noop () {}

--- a/server.js
+++ b/server.js
@@ -585,7 +585,7 @@ Server.prototype._onWebSocketClose = function (socket) {
   debug('websocket close %s', socket.peerId)
 
   if (socket.peerId) {
-    socket.infoHashes.forEach(function (infoHash) {
+    socket.infoHashes.slice(0).forEach(function (infoHash) {
       var swarm = self.torrents[infoHash]
       if (swarm) {
         swarm.announce({

--- a/test/evict.js
+++ b/test/evict.js
@@ -1,0 +1,126 @@
+var Buffer = require('safe-buffer').Buffer
+var Client = require('../')
+var common = require('./common')
+var test = require('tape')
+var electronWebrtc = require('electron-webrtc')
+
+var wrtc
+
+var infoHash = '4cb67059ed6bd08362da625b3ae77f6f4a075705'
+var peerId = Buffer.from('01234567890123456789')
+var peerId2 = Buffer.from('12345678901234567890')
+var peerId3 = Buffer.from('23456789012345678901')
+
+function serverTest (t, serverType, serverFamily) {
+  t.plan(10)
+
+  var hostname = serverFamily === 'inet6'
+    ? '[::1]'
+    : '127.0.0.1'
+
+  var opts = {
+    serverType: serverType,
+    peersCacheLength: 2 // LRU cache can only contain a max of 2 peers
+  }
+
+  common.createServer(t, opts, function (server) {
+    // Not using announceUrl param from `common.createServer()` since we
+    // want to control IPv4 vs IPv6.
+    var port = server[serverType].address().port
+    var announceUrl = serverType + '://' + hostname + ':' + port + '/announce'
+
+    var client1 = new Client({
+      infoHash: infoHash,
+      announce: [ announceUrl ],
+      peerId: peerId,
+      port: 6881,
+      wrtc: wrtc
+    })
+    if (serverType === 'ws') common.mockWebsocketTracker(client1)
+
+    client1.start()
+
+    client1.once('update', function (data) {
+      var client2 = new Client({
+        infoHash: infoHash,
+        announce: [ announceUrl ],
+        peerId: peerId2,
+        port: 6882,
+        wrtc: wrtc
+      })
+      if (serverType === 'ws') common.mockWebsocketTracker(client2)
+
+      client2.start()
+
+      client2.once('update', function (data) {
+        server.getSwarm(infoHash, function (err, swarm) {
+          t.error(err)
+
+          t.equal(swarm.complete + swarm.incomplete, 2)
+
+          // Ensure that first peer is evicted when a third one is added
+          var evicted = false
+          swarm.peers.once('evict', function (evictedPeer) {
+            t.equal(evictedPeer.value.peerId, peerId.toString('hex'))
+            t.equal(swarm.complete + swarm.incomplete, 2)
+            evicted = true
+          })
+
+          var client3 = new Client({
+            infoHash: infoHash,
+            announce: [ announceUrl ],
+            peerId: peerId3,
+            port: 6880,
+            wrtc: wrtc
+          })
+          if (serverType === 'ws') common.mockWebsocketTracker(client3)
+
+          client3.start()
+
+          client3.once('update', function (data) {
+            t.ok(evicted, 'client1 was evicted from server before client3 gets response')
+            t.equal(swarm.complete + swarm.incomplete, 2)
+
+            client1.destroy(function () {
+              t.pass('client1 destroyed')
+            })
+
+            client2.destroy(function () {
+              t.pass('client3 destroyed')
+            })
+
+            client3.destroy(function () {
+              t.pass('client3 destroyed')
+            })
+
+            server.close(function () {
+              t.pass('server destroyed')
+            })
+          })
+        })
+      })
+    })
+  })
+}
+
+test('evict: ipv4 server', function (t) {
+  serverTest(t, 'http', 'inet')
+})
+
+test('evict: http ipv6 server', function (t) {
+  serverTest(t, 'http', 'inet6')
+})
+
+test('evict: udp server', function (t) {
+  serverTest(t, 'udp', 'inet')
+})
+
+test('evict: ws server', function (t) {
+  wrtc = electronWebrtc()
+  wrtc.electronDaemon.once('ready', function () {
+    serverTest(t, 'ws', 'inet')
+  })
+  t.once('end', function () {
+    wrtc.close()
+  })
+})

--- a/test/server.js
+++ b/test/server.js
@@ -25,8 +25,7 @@ function serverTest (t, serverType, serverFamily) {
     : '127.0.0.1'
 
   var opts = {
-    serverType: serverType,
-    peersCacheLength: 2
+    serverType: serverType
   }
 
   common.createServer(t, opts, function (server) {

--- a/test/server.js
+++ b/test/server.js
@@ -2,12 +2,9 @@ var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var test = require('tape')
-var wrtc = require('electron-webrtc')()
+var electronWebrtc = require('electron-webrtc')
 
-var wrtcReady = false
-wrtc.electronDaemon.once('ready', function () {
-  wrtcReady = true
-})
+var wrtc
 
 var infoHash = '4cb67059ed6bd08362da625b3ae77f6f4a075705'
 var peerId = Buffer.from('01234567890123456789')
@@ -177,15 +174,11 @@ test('udp server', function (t) {
 })
 
 test('ws server', function (t) {
-  if (wrtcReady) {
-    runTest()
-  } else {
-    wrtc.electronDaemon.once('ready', runTest)
-  }
-  function runTest () {
-    t.once('end', function () {
-      wrtc.close()
-    })
+  wrtc = electronWebrtc()
+  wrtc.electronDaemon.once('ready', function () {
     serverTest(t, 'ws', 'inet')
-  }
+  })
+  t.once('end', function () {
+    wrtc.close()
+  })
 })

--- a/test/server.js
+++ b/test/server.js
@@ -12,7 +12,7 @@ var peerId2 = Buffer.from('12345678901234567890')
 var peerId3 = Buffer.from('23456789012345678901')
 
 function serverTest (t, serverType, serverFamily) {
-  t.plan(36)
+  t.plan(40)
 
   var hostname = serverFamily === 'inet6'
     ? '[::1]'
@@ -138,16 +138,23 @@ function serverTest (t, serverType, serverFamily) {
                   t.equal(data.incomplete, 1)
 
                   client2.destroy(function () {
+                    t.pass('client2 destroyed')
                     client3.stop()
                     client3.once('update', function (data) {
                       t.equal(data.announce, announceUrl)
                       t.equal(data.complete, 1)
                       t.equal(data.incomplete, 0)
 
+                      client1.destroy(function () {
+                        t.pass('client1 destroyed')
+                      })
+
                       client3.destroy(function () {
-                        client1.destroy(function () {
-                          server.close()
-                        })
+                        t.pass('client3 destroyed')
+                      })
+
+                      server.close(function () {
+                        t.pass('server destroyed')
                       })
                     })
                   })


### PR DESCRIPTION
Possibly fixes: https://github.com/feross/bittorrent-tracker/issues/196

Close websockets when peers are evicted from LRU cache, otherwise it's
possible for a peer object to be evicted from the LRU cache without the
socket being cleaned up. That will leak memory until the websocket is
closed by the remote client. It also messes up the stats.