### PR TITLE
perf: disable perMessageDeflate

### DIFF
--- a/server.js
+++ b/server.js
@@ -118,7 +118,7 @@ function Server (opts) {
         })
       })
     }
-    self.ws = new WebSocketServer({ server: self.http })
+    self.ws = new WebSocketServer({ server: self.http, perMessageDeflate: false })
     self.ws.address = function () {
       return self.http.address()
     }


### PR DESCRIPTION
From the ws docs:

"ws supports the permessage-deflate extension extension which enables
the client and server to negotiate a compression algorithm and its
parameters, and then selectively apply it to the data payloads of each
WebSocket message.

The extension is enabled by default but adds a significant overhead in
terms of performance and memory comsumption. We suggest to use
WebSocket compression only if it is really needed.

To disable the extension you can set the perMessageDeflate option to
false"