### PR TITLE
use `btparse` instead of `bencode`

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -1,7 +1,7 @@
 module.exports = HTTPTracker
 
 var arrayRemove = require('unordered-array-remove')
-var bencode = require('bencode')
+var btparse = require('btparse')
 var compact2string = require('compact2string')
 var debug = require('debug')('bittorrent-tracker:http-tracker')
 var extend = require('xtend')
@@ -156,7 +156,7 @@ HTTPTracker.prototype._request = function (requestUrl, params, cb) {
     }
 
     try {
-      data = bencode.decode(data)
+      data = btparse(data)
     } catch (err) {
       return cb(new Error('Error decoding tracker response: ' + err.message))
     }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "url": "https://github.com/feross/bittorrent-tracker/issues"
   },
   "dependencies": {
-    "bencode": "^0.11.0",
     "bittorrent-peerid": "^1.0.2",
     "bn.js": "^4.4.0",
+    "btparse": "^1.0.2",
     "compact2string": "^1.2.0",
     "debug": "^2.0.0",
     "inherits": "^2.0.1",

--- a/test/scrape.js
+++ b/test/scrape.js
@@ -1,4 +1,4 @@
-var bencode = require('bencode')
+var btparse = require('btparse')
 var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
@@ -169,7 +169,7 @@ test('server: multiple info_hash scrape (manual http request)', function (t) {
 
       t.equal(res.statusCode, 200)
 
-      data = bencode.decode(data)
+      data = btparse(data)
       t.ok(data.files)
       t.equal(Object.keys(data.files).length, 2)
 
@@ -214,7 +214,7 @@ test('server: all info_hash scrape (manual http request)', function (t) {
         t.error(err)
 
         t.equal(res.statusCode, 200)
-        data = bencode.decode(data)
+        data = btparse(data)
         t.ok(data.files)
         t.equal(Object.keys(data.files).length, 1)
 


### PR DESCRIPTION
[`btparse`](https://github.com/ReklatsMasters/btparse) is my a bit faster alternative to `bencode.decode`. 

perf tests from readme:

*nodejs 7.5.0 / windows 10 x64 / i5 4690*

|Library| op/s | ms (1e5 op) |
|-------|:---:|:---:|
|bencode| 118,387| 838.424 |
|btparse| 161,059 | 641.632 |

The main known difference is a bit strict number checks (follow spec of course). 