### PR TITLE
add bufferutil as optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "tape": "^4.0.0",
     "webtorrent-fixtures": "^1.3.0"
   },
+  "optionalDependencies": {
+    "bufferutil": "^3.0.0"
+  },
   "keywords": [
     "bittorrent",
     "p2p",


### PR DESCRIPTION
[`bufferutil`](https://github.com/websockets/bufferutil) greatly improves `ws` performance.
The package now has prebuilt binaries for Node.js 4, 6 and 7 (darwin, win32 and linux).

This should help with #175.

Slightly off-topic: memory usage can be reduced by ~15% if `ws.upgradeReq` is freed when it is no longer needed.