### PR TITLE
Delete `socket.upgradeReq` when it is no longer needed to reduce memory usage

### DIFF
--- a/lib/server/parse-websocket.js
+++ b/lib/server/parse-websocket.js
@@ -52,15 +52,27 @@ function parseWebSocketRequest (socket, opts, params) {
     throw new Error('invalid action in WS request: ' + params.action)
   }
 
-  params.ip = opts.trustProxy
-      ? socket.upgradeReq.headers['x-forwarded-for'] || socket.upgradeReq.connection.remoteAddress
-      : socket.upgradeReq.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force ipv4
-  params.port = socket.upgradeReq.connection.remotePort
-  if (params.port) {
-    params.addr = (common.IPV6_RE.test(params.ip) ? '[' + params.ip + ']' : params.ip) + ':' + params.port
+  // On first parse, save important data from `socket.upgradeReq` and delete it
+  // to reduce memory usage.
+  if (socket.upgradeReq) {
+    socket.ip = opts.trustProxy
+        ? socket.upgradeReq.headers['x-forwarded-for'] || socket.upgradeReq.connection.remoteAddress
+        : socket.upgradeReq.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force ipv4
+    socket.port = socket.upgradeReq.connection.remotePort
+    if (socket.port) {
+      socket.addr = (common.IPV6_RE.test(socket.ip) ? '[' + socket.ip + ']' : socket.ip) + ':' + socket.port
+    }
+
+    socket.headers = socket.upgradeReq.headers
+
+    // Delete `socket.upgradeReq` when it is no longer needed to reduce memory usage
+    socket.upgradeReq = null
   }
 
-  params.headers = socket.upgradeReq.headers
+  params.ip = socket.ip
+  params.port = socket.port
+  params.addr = socket.addr
+  params.headers = socket.headers
 
   return params
 }


### PR DESCRIPTION
Each time a websocket sends a request, `parseWebSocketRequest` is called. On the first parse, save important data from `socket.upgradeReq` and delete it to reduce memory usage.

cc @lpinca @DiegoRBaquero 