### PR TITLE
Expose swarm object on tracker server

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -190,11 +190,11 @@ HTTPTracker.prototype._onAnnounceResponse = function (data) {
     self._trackerId = trackerId
   }
 
-  self.client.emit('update', {
+  var response = Object.assign({}, data, {
     announce: self.announceUrl,
-    complete: data.complete,
-    incomplete: data.incomplete
+    infoHash: common.binaryToHex(data.info_hash)
   })
+  self.client.emit('update', response)
 
   var addrs
   if (Buffer.isBuffer(data.peers)) {
@@ -248,15 +248,12 @@ HTTPTracker.prototype._onScrapeResponse = function (data) {
   }
 
   keys.forEach(function (infoHash) {
-    var response = data[infoHash]
     // TODO: optionally handle data.flags.min_request_interval
     // (separate from announce interval)
-    self.client.emit('scrape', {
+    var response = Object.assign(data[infoHash], {
       announce: self.announceUrl,
-      infoHash: common.binaryToHex(infoHash),
-      complete: response.complete,
-      incomplete: response.incomplete,
-      downloaded: response.downloaded
+      infoHash: common.binaryToHex(infoHash)
     })
+    self.client.emit('scrape', response)
   })
 }

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -266,8 +266,11 @@ WebSocketTracker.prototype._onAnnounceResponse = function (data) {
   }
 
   if (data.complete != null) {
-    data.announce = self.announceUrl
-    self.client.emit('update', data)
+    var response = Object.assign({}, data, {
+      announce: self.announceUrl,
+      infoHash: common.binaryToHex(data.info_hash)
+    })
+    self.client.emit('update', response)
   }
 
   var peer
@@ -323,16 +326,13 @@ WebSocketTracker.prototype._onScrapeResponse = function (data) {
   }
 
   keys.forEach(function (infoHash) {
-    var response = data[infoHash]
     // TODO: optionally handle data.flags.min_request_interval
     // (separate from announce interval)
-    self.client.emit('scrape', {
+    var response = Object.assign(data[infoHash], {
       announce: self.announceUrl,
-      infoHash: common.binaryToHex(infoHash),
-      complete: response.complete,
-      incomplete: response.incomplete,
-      downloaded: response.downloaded
+      infoHash: common.binaryToHex(infoHash)
     })
+    self.client.emit('scrape', response)
   })
 }
 

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -266,11 +266,8 @@ WebSocketTracker.prototype._onAnnounceResponse = function (data) {
   }
 
   if (data.complete != null) {
-    self.client.emit('update', {
-      announce: self.announceUrl,
-      complete: data.complete,
-      incomplete: data.incomplete
-    })
+    data.announce = self.announceUrl
+    self.client.emit('update', data)
   }
 
   var peer

--- a/server.js
+++ b/server.js
@@ -27,14 +27,15 @@ inherits(Server, EventEmitter)
  * metrics from clients that help the tracker keep overall statistics about the torrent.
  * Responses include a peer list that helps the client participate in the torrent.
  *
- * @param {Object}  opts            options object
- * @param {Number}  opts.interval   tell clients to announce on this interval (ms)
- * @param {Number}  opts.trustProxy trust 'x-forwarded-for' header from reverse proxy
- * @param {boolean} opts.http       start an http server? (default: true)
- * @param {boolean} opts.udp        start a udp server? (default: true)
- * @param {boolean} opts.ws         start a websocket server? (default: true)
- * @param {boolean} opts.stats      enable web-based statistics? (default: true)
- * @param {function} opts.filter    black/whitelist fn for disallowing/allowing torrents
+ * @param {Object}  opts                  options object
+ * @param {Number}  opts.interval         tell clients to announce on this interval (ms)
+ * @param {Number}  opts.trustProxy       trust 'x-forwarded-for' header from reverse proxy
+ * @param {boolean} opts.http             start an http server? (default: true)
+ * @param {boolean} opts.udp              start a udp server? (default: true)
+ * @param {boolean} opts.ws               start a websocket server? (default: true)
+ * @param {boolean} opts.stats            enable web-based statistics? (default: true)
+ * @param {function} opts.filter          black/whitelist fn for disallowing/allowing torrents
+ * @param {function} opts.requestHandler  functions to handle params / response
  */
 function Server (opts) {
   var self = this
@@ -63,6 +64,18 @@ function Server (opts) {
   self.udp4 = null
   self.udp6 = null
   self.ws = null
+
+  self._reqHandler = opts.requestHandler || {}
+  if (!self._reqHandler.getParams) {
+    self._reqHandler.getParams = function (params) {
+      return params
+    }
+  }
+  if (!self._reqHandler.getResponse) {
+    self._reqHandler.getResponse = function (params, cb) {
+      return cb
+    }
+  }
 
   // start an http tracker unless the user explictly says no
   if (opts.http !== false) {
@@ -636,6 +649,8 @@ Server.prototype._onWebSocketError = function (socket, err) {
 
 Server.prototype._onRequest = function (params, cb) {
   var self = this
+  params = self._reqHandler.getParams(params)
+  cb = self._reqHandler.getResponse(params, cb)
   if (params && params.action === common.ACTIONS.CONNECT) {
     cb(null, { action: common.ACTIONS.CONNECT })
   } else if (params && params.action === common.ACTIONS.ANNOUNCE) {

--- a/test/request-handler.js
+++ b/test/request-handler.js
@@ -1,0 +1,70 @@
+var Buffer = require('safe-buffer').Buffer
+var Client = require('../')
+var common = require('./common')
+var fixtures = require('webtorrent-fixtures')
+var test = require('tape')
+
+var peerId = Buffer.from('01234567890123456789')
+
+function testRequestHandler (t, serverType) {
+  t.plan(4)
+
+  var opts = { serverType: serverType } // this is test-suite-only option
+  opts.requestHandler = {
+    getParams: function (params) {
+      params.extra = 123
+      return params
+    },
+    getResponse: function (params, cb) {
+      return function (err, response) {
+        response.complete = params.extra * 2
+        cb(err, response)
+      }
+    }
+  }
+
+  common.createServer(t, opts, function (server, announceUrl) {
+    var client1 = new Client({
+      infoHash: fixtures.alice.parsedTorrent.infoHash,
+      announce: announceUrl,
+      peerId: peerId,
+      port: 6881,
+      wrtc: {}
+    })
+
+    client1.on('error', function (err) { t.error(err) })
+    if (serverType === 'ws') common.mockWebsocketTracker(client1)
+
+    server.once('start', function () {
+      t.pass('got start message from client1')
+    })
+
+    client1.once('update', function (data) {
+      console.log(data)
+
+      t.equal(data.complete, 246)
+
+      client1.destroy(function () {
+        t.pass('client1 destroyed')
+      })
+
+      server.close(function () {
+        t.pass('server destroyed')
+      })
+    })
+
+    client1.start()
+  })
+}
+
+test('http: request handler option intercepts announce requests and responses', function (t) {
+  testRequestHandler(t, 'http')
+})
+
+test('udp: request handler option intercepts announce requests and responses', function (t) {
+  testRequestHandler(t, 'udp')
+})
+
+test('ws: request handler option intercepts announce requests and responses', function (t) {
+  testRequestHandler(t, 'ws')
+})

--- a/test/request-handler.js
+++ b/test/request-handler.js
@@ -40,8 +40,6 @@ function testRequestHandler (t, serverType) {
     })
 
     client1.once('update', function (data) {
-      console.log(data)
-
       t.equal(data.complete, 246)
 
       client1.destroy(function () {

--- a/test/request-handler.js
+++ b/test/request-handler.js
@@ -3,25 +3,32 @@ var Client = require('../')
 var common = require('./common')
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
+var Server = require('../server')
 
 var peerId = Buffer.from('01234567890123456789')
 
 function testRequestHandler (t, serverType) {
-  t.plan(4)
+  t.plan(5)
 
   var opts = { serverType: serverType } // this is test-suite-only option
-  opts.requestHandler = {
-    getParams: function (params) {
-      params.extra = 123
-      return params
-    },
-    getResponse: function (params, cb) {
-      return function (err, response) {
-        response.complete = params.extra * 2
-        cb(err, response)
-      }
+
+  class Swarm extends Server.Swarm {
+    announce (params, cb) {
+      super.announce(params, function (err, response) {
+        if (err) return cb(response)
+        response.complete = 246
+        response.extraData = 'hi'
+        cb(null, response)
+      })
     }
   }
+
+  // Use a custom Swarm implementation for this test only
+  var OldSwarm = Server.Swarm
+  Server.Swarm = Swarm
+  t.on('end', function () {
+    Server.Swarm = OldSwarm
+  })
 
   common.createServer(t, opts, function (server, announceUrl) {
     var client1 = new Client({
@@ -41,6 +48,7 @@ function testRequestHandler (t, serverType) {
 
     client1.once('update', function (data) {
       t.equal(data.complete, 246)
+      t.equal(data.extraData.toString(), 'hi')
 
       client1.destroy(function () {
         t.pass('client1 destroyed')
@@ -59,10 +67,8 @@ test('http: request handler option intercepts announce requests and responses', 
   testRequestHandler(t, 'http')
 })
 
-test('udp: request handler option intercepts announce requests and responses', function (t) {
-  testRequestHandler(t, 'udp')
-})
-
 test('ws: request handler option intercepts announce requests and responses', function (t) {
   testRequestHandler(t, 'ws')
 })
+
+// NOTE: it's not possible to include extra data in a UDP response, because it's compact and accepts only params that are in the spec!


### PR DESCRIPTION
This PR allows a server tracker to intercept announce request and responses. I use it to provide extra data to peers.

I don't expect this PR to be reviewed either, I post this in case someone is interested.
Tell me if you don't want PRs like that anymore...

I tried to clarify this in #207 but I did not have any clue after 2 weeks.