### PR TITLE
Handle peer 'error' events correctly

### DIFF
--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -276,7 +276,7 @@ WebSocketTracker.prototype._onAnnounceResponse = function (data) {
   var peer
   if (data.offer && data.peer_id) {
     debug('creating peer (from remote offer)')
-    peer = new Peer({
+    peer = self._createPeer({
       trickle: false,
       config: self.client._rtcConfig,
       wrtc: self.client._wrtc
@@ -389,7 +389,7 @@ WebSocketTracker.prototype._generateOffers = function (numwant, cb) {
   function generateOffer () {
     var offerId = randombytes(20).toString('hex')
     debug('creating peer (from _generateOffers)')
-    var peer = self.peers[offerId] = new Peer({
+    var peer = self.peers[offerId] = self._createPeer({
       initiator: true,
       trickle: false,
       config: self.client._rtcConfig,
@@ -416,6 +416,30 @@ WebSocketTracker.prototype._generateOffers = function (numwant, cb) {
       debug('generated %s offers', numwant)
       cb(offers)
     }
+  }
+}
+
+WebSocketTracker.prototype._createPeer = function (opts) {
+  var self = this
+  var peer = new Peer(opts)
+
+  peer.once('error', onError)
+  peer.once('connect', onConnect)
+
+  return peer
+
+  // Handle peer 'error' events that are fired *before* the peer is emitted in
+  // a 'peer' event.
+  function onError (err) {
+    self.client.emit('warning', new Error('Connection error: ' + err.message))
+    peer.destroy()
+  }
+
+  // Once the peer is emitted in a 'peer' event, then it's the consumer's
+  // responsibility to listen for errors, so the listeners are removed here.
+  function onConnect () {
+    peer.removeListener('error', onError)
+    peer.removeListener('connect', onConnect)
   }
 }
 


### PR DESCRIPTION
Handle peer 'error' events that are fired *before* the peer is emitted
in a 'peer' event. Once the peer is emitted in a 'peer' event, then
it's the consumer's responsibility to listen for errors.

This fixes the most common error in WebTorrent Desktop according to our
telemetry.

<img width="701" alt="screen shot 2017-04-07 at 5 33 45 pm" src="https://cloud.githubusercontent.com/assets/121766/24823898/866b5c72-1bb8-11e7-930a-aba8ca779e0f.png">
